### PR TITLE
[gst-plugins-bad] Add support for AptX (bluetooth)

### DIFF
--- a/rpm/gst-plugins-bad.spec
+++ b/rpm/gst-plugins-bad.spec
@@ -47,6 +47,7 @@ BuildRequires: pkgconfig(sbc)
 BuildRequires: pkgconfig(libsrtp2)
 BuildRequires: pkgconfig(sndfile)
 BuildRequires: pkgconfig(libdrm)
+BuildRequires: pkgconfig(libfreeaptx)
 %ifnarch %{ix86} x86_64
 BuildRequires: libatomic
 %endif
@@ -107,7 +108,7 @@ GStreamer Plugins Bad library applications
   -Dmidi=disabled -Dmodplug=disabled -Dmpeg2enc=disabled -Dmpegpsmux=disabled \
   -Dmpegtsmux=disabled -Dmplex=disabled -Dmsdk=disabled -Dmusepack=disabled \
   -Dmxf=disabled -Dneon=disabled -Dnvcomp=disabled -Dnvdswrapper=disabled -Donnx=disabled \
-  -Dopenal=disabled -Dopenaptx=disabled -Dopencv=disabled -Dopenexr=disabled \
+  -Dopenal=disabled -Dopenaptx=enabled -Dopencv=disabled -Dopenexr=disabled \
   -Dopenh264=disabled -Dopenmpt=disabled -Dopenni2=disabled -Dopensles=disabled \
   -Dpcapparse=disabled -Dpnm=disabled -Dqroverlay=disabled -Dqsv=disabled \
   -Dqt6d3d11=disabled \


### PR DESCRIPTION
This enables support for the AptX bluetooth audio codec.

It requires a new library, freeaptx.
Packaging for this is available at: https://github.com/nephros/libfreeaptx.git

Please advise on how to get this into the sailfishos GitHub org.

To test, builds are available at OBS: https://build.sailfishos.org/project/monitor/home:nephros:devel:gst-bluetooth
